### PR TITLE
TOR-9 fix: error when `keys list` has no keys

### DIFF
--- a/src/torusdk/cli/key.py
+++ b/src/torusdk/cli/key.py
@@ -204,9 +204,15 @@ def inventory(
     general_key_to_address: dict[str, str] = cast(
         dict[str, str], key_to_address
     )
+
     print_table_from_plain_dict(
         general_key_to_address, ["Key", "Address"], context.console
     )
+
+    total = len(key_to_address)
+
+    # print total rows
+    context.info(f"{total} row{'s' if total != 1 else ''}.")
 
 
 @key_app.command()

--- a/src/torusdk/cli/key.py
+++ b/src/torusdk/cli/key.py
@@ -211,7 +211,6 @@ def inventory(
 
     total = len(key_to_address)
 
-    # print total rows
     context.info(f"{total} row{'s' if total != 1 else ''}.")
 
 

--- a/src/torusdk/key.py
+++ b/src/torusdk/key.py
@@ -60,6 +60,10 @@ def local_key_adresses(
 
     key_dir = os.path.expanduser(os.path.join(TORUS_HOME, "key"))
     key_dir = Path(key_dir)
+
+    if not key_dir.exists():
+        return {}
+
     key_names = [
         f.stem
         for f in key_dir.iterdir()


### PR DESCRIPTION
If you try to list your keys before creating one, a weird error is shown (basically, "path doesn't exist")

Now, if you list before the path is created, an empty list is shown.

Also added the total number of rows, if it's a good thing to keep, we could add it to `print_table_from_plain_dict`:
```bash
$ torus key list
┏━━━━━┳━━━━━━━━━┓
┃ Key ┃ Address ┃
┡━━━━━╇━━━━━━━━━┩
└─────┴─────────┘
0 rows.
$ torus key list
┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Key    ┃ Address                                          ┃
┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ teste2 │ 5E2ceQK3xNyDqbDdLgUukY3cohrBpuG5Ft1ZxfVkfzkFjzZA │
│ teste  │ 5Ci9UQBdYJxoLHHcepqyuskMcqmnr3oQ8UjPgwpVbJVmPdup │
└────────┴──────────────────────────────────────────────────┘
2 rows.
```